### PR TITLE
Fix zero sids in OIDs

### DIFF
--- a/Asn1/Asn1ObjectIdentifier.cs
+++ b/Asn1/Asn1ObjectIdentifier.cs
@@ -101,6 +101,11 @@ namespace Asn1 {
         }
 
         private static void Write(Stream mem, ulong val) {
+            if (val == 0) {
+                mem.WriteByte(0);
+                return;
+            }
+
             var zero = true;
             for (var i = 9; i >= 0; i--) {
                 var subval = (val >> (i * 7)) & 0x7ful;


### PR DESCRIPTION
Hi. Found a little bug: zero sids of object ids are not written into bytes.

E.g. OID `1.2.643.2.2.36.0` (CryptoPro ell.curve XA for GOST R 34.11-2001) is being output this way: 

```
06 06  2A 85 03 02 02 24
```

While it should be output like this (notice the trailing zero):

```
06 07  2A 85 03 02 02 24 00
```