### PR TITLE
Add ability to override default encoding of "true" value.

### DIFF
--- a/Asn1/Asn1Boolean.cs
+++ b/Asn1/Asn1Boolean.cs
@@ -6,6 +6,8 @@ namespace Asn1 {
 
         public const string NODE_NAME = "Boolean";
 
+        public static byte TrueValue { get; set; } = 1;
+        
         public bool Value { get; set; }
 
         public Asn1Boolean(bool value) {
@@ -29,7 +31,7 @@ namespace Asn1 {
         }
 
         protected override byte[] GetBytesCore() {
-            return new[] { (byte)(Value ? 1 : 0) };
+            return new[] { (byte)(Value ? TrueValue : 0) };
         }
 
         public new static Asn1Boolean Parse(XElement xNode) {


### PR DESCRIPTION
 Accordings to T-REC-X.690-201508 11.1, 8.2 it should be 0xFF
https://docs.microsoft.com/en-us/windows/win32/seccertenroll/about-boolean